### PR TITLE
Add file flag to read JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ USAGE:
 
 OPTIONS:
     -e, --endpoint <ENDPOINT>          Node endpoint URL [default: http://localhost:2020/graphql]
+    -f, --file <FILE>                  Optional path to JSON file to parse the operation else reads
+                                       piped JSON file from stdin
     -h, --help                         Print help information
     -k, --private-key <PRIVATE_KEY>    Path to private key file [default: key.txt]
     -V, --version                      Print version information


### PR DESCRIPTION
Hi 👋, I've been poking around with p2panda and I think this would be a great addition for send-to-node.

To make it easier to work with send-to-node, this pull request adds an optional `file` flag which is the path to read the JSON file.

```bash
cat 001-schema-field-definition-name.json | cargo run -- -k ./key-demo.txt
# or
cargo run -- -k ./key-demo.txt -f 001-schema-field-definition-name.json
```

also I replaced the match statement inside the `get_key_pair` for an if-else statement that sets the `private_key`.
